### PR TITLE
Fix AICP Bootanimation on surnia

### DIFF
--- a/products/surnia.mk
+++ b/products/surnia.mk
@@ -38,3 +38,7 @@ PRODUCT_RELEASE_NAME := surnia
 
 PRODUCT_BUILD_PROP_OVERRIDES += \
     PRODUCT_NAME="Moto E LTE (2nd gen)"
+
+# Copy bootanimation for surnia
+PRODUCT_COPY_FILES +=  \
+    vendor/aicp/prebuilt/bootanimation/bootanimation_540_960.zip:system/media/bootanimation.zip


### PR DESCRIPTION
This commit adds a line to copy the right bootanimation for surnia, without this, it shows the "Android" bootanimation (that one that appears when there's no bootanimation on system/media)
This should fix this small aesthetic bug
