### PR TITLE
add shamrock device info 

### DIFF
--- a/products/AndroidProducts.mk
+++ b/products/AndroidProducts.mk
@@ -65,6 +65,7 @@ PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/serranodsdd.mk \
     $(LOCAL_DIR)/shamu.mk \
     $(LOCAL_DIR)/shieldtablet.mk \
+    $(LOCAL_DIR)/shamrock.mk \
     $(LOCAL_DIR)/sprout4.mk \
     $(LOCAL_DIR)/surnia.mk \
     $(LOCAL_DIR)/T00F.mk \

--- a/products/shamrock.mk
+++ b/products/shamrock.mk
@@ -15,7 +15,7 @@ $(call inherit-product, device/google/shamrock/full_shamrock.mk)
 # Inherit telephony stuff
 $(call inherit-product, vendor/aicp/configs/telephony.mk)
 # Inherit some common AICP stuff.
-$(call inherit-product, vendor/aicp/common.mk)
+$(call inherit-product, vendor/aicp/configs/common.mk)
 # Must define platform variant before including any common things
 TARGET_BOARD_PLATFORM_VARIANT := msm8952
 PRODUCT_NAME := aicp_shamrock

--- a/products/shamrock.mk
+++ b/products/shamrock.mk
@@ -30,6 +30,6 @@ TARGET_VENDOR_DEVICE_NAME := shamrock
 
 # AICP Device Maintainers
 PRODUCT_BUILD_PROP_OVERRIDES += \
-	DEVICE_MAINTAINERS="Caner Aydın (Deftones)"
-  DEVICE_MAINTAINERS="Vedat Ak (Incredible)"
-  DEVICE_MAINTAINERS="Kaan Külahlı (Rygebin)"
+	DEVICE_MAINTAINERS="Caner Aydın (Deftones)" \
+  	DEVICE_MAINTAINERS="Vedat Ak (Incredible)" \
+  	DEVICE_MAINTAINERS="Kaan Külahlı (Rygebin)" 

--- a/products/shamrock.mk
+++ b/products/shamrock.mk
@@ -1,0 +1,35 @@
+# Copyright (C) 2016 The AİCP Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+$(call inherit-product, device/google/shamrock/full_shamrock.mk)
+# Inherit telephony stuff
+$(call inherit-product, vendor/aicp/configs/telephony.mk)
+# Inherit some common AICP stuff.
+$(call inherit-product, vendor/aicp/common.mk)
+# Must define platform variant before including any common things
+TARGET_BOARD_PLATFORM_VARIANT := msm8952
+PRODUCT_NAME := aicp_shamrock
+BOARD_VENDOR := google
+PRODUCT_DEVICE := shamrock
+PRODUCT_GMS_CLIENTID_BASE := android-google
+PRODUCT_MANUFACTURER := Google
+PRODUCT_BRAND := Google
+TARGET_VENDOR := google
+TARGET_VENDOR_PRODUCT_NAME := Shamrock
+TARGET_VENDOR_DEVICE_NAME := shamrock
+
+# AICP Device Maintainers
+PRODUCT_BUILD_PROP_OVERRIDES += \
+	DEVICE_MAINTAINERS="Caner Aydın (Deftones)"
+  DEVICE_MAINTAINERS="Vedat Ak (Incredible)"
+  DEVICE_MAINTAINERS="Kaan Külahlı (Rygebin)"


### PR DESCRIPTION
it preapare Aicp for  Android One 3'rd Devices source tree.  it can transfer the official repo. Prepared as team work. 

at link's below . 
 
Device Tree :  https://github.com/OneTeamDevelopment/android_device_google_shamrock
Device Common Tree : https://github.com/OneTeamDevelopment/android_device_google_msm8952-common
Vendor Tree : https://github.com/OneTeamDevelopment/proprietary_vendor_google
Kernel Tree : https://github.com/OneTeamDevelopment/android_kernel_google_shamrock

@LorDClockaN @semdoc 