### PR TITLE
peach: Add peach device

### DIFF
--- a/products/AndroidProducts.mk
+++ b/products/AndroidProducts.mk
@@ -62,6 +62,7 @@ PRODUCT_MAKEFILES := \
     $(LOCAL_DIR)/otus.mk \
     $(LOCAL_DIR)/onyx.mk \
     $(LOCAL_DIR)/peregrine.mk \
+    $(LOCAL_DIR)/peach.mk \
     $(LOCAL_DIR)/seed.mk \
     $(LOCAL_DIR)/serranodsdd.mk \
     $(LOCAL_DIR)/shamu.mk \

--- a/products/peach.mk
+++ b/products/peach.mk
@@ -1,0 +1,49 @@
+# Copyright (C) 2015 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
+
+$(call inherit-product, device/ark/peach/device.mk)
+
+# Inherit some common AICP stuff.
+$(call inherit-product, vendor/aicp/configs/common.mk)
+
+# Inherit telephony stuff
+$(call inherit-product, vendor/aicp/configs/telephony.mk)
+
+# Assert
+TARGET_OTA_ASSERT_DEVICE := peach,benefit,ark_benefit_a3,benefit_a3,a3,ark
+
+# Must define platform variant before including any common things
+TARGET_BOARD_PLATFORM_VARIANT := msm8916
+
+PRODUCT_BRAND := ARK
+PRODUCT_NAME := aicp_peach
+BOARD_VENDOR := ark
+PRODUCT_DEVICE := peach
+PRODUCT_MANUFACTURER := ARK
+PRODUCT_MODEL := Benefit A3
+
+PRODUCT_GMS_CLIENTID_BASE := android-elephone
+
+
+# AICP Device Maintainers
+PRODUCT_BUILD_PROP_OVERRIDES += \
+	DEVICE_MAINTAINERS="Ilya Lebedev (lol_max_lik)"
+
+# Boot animation
+TARGET_SCREEN_HEIGHT := 1280
+TARGET_SCREEN_WIDTH := 720
+-include vendor/aicp/configs/bootanimation.mk


### PR DESCRIPTION
This is a prepared device tree for build AICP12.1 for ARK Benefit A3.

Links:
Device Tree: https://github.com/BenefitA3/android_device_ark_peach/tree/aicp-n7.1
Vendor Tree: https://github.com/BenefitA3/proprietary_vendor_ark/tree/cm-14.1-wip
Kernel Tree: https://github.com/BenefitA3/android_kernel_ark_msm8916/tree/cm-14.1-wip 

@LorDClockaN @semdoc